### PR TITLE
feat: add link and type input to new restaurant form

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "@testing-library/user-event": "^12.1.10",
   "antd": "^4.16.6",
   "craco-less": "^1.18.0",
+  "nanoid": "^3.1.23",
   "react": "^17.0.2",
   "react-dom": "^17.0.2",
   "react-scripts": "4.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -11,20 +11,26 @@ function App() {
   {
    restaurant: 'Bakemono Bakers',
    suburb: 'CBD',
+   type: 'Cafe',
    price: '$',
+   link: 'https://www.bakemonobakers.com.au/',
    notes:
     'Belinda recommended the garlic cream cheese bread and take home matcha latte kit',
   },
   {
    restaurant: 'Marko',
    suburb: 'South Melbourne',
+   type: 'Restaurant',
    price: '$',
+   link: 'https://www.instagram.com/eatmarko/',
    notes: undefined,
   },
   {
    restaurant: 'Aru',
    suburb: 'CBD',
+   type: 'Restaurant',
    price: '$$$',
+   link: 'https://www.broadsheet.com.au/melbourne/restaurants/aru-dining',
    notes: 'Bianca recommended the dry aged duck and claypot rice',
   },
  ]

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ function App() {
    suburb: 'South Melbourne',
    type: 'Restaurant',
    price: '$',
-   link: 'https://www.instagram.com/eatmarko/',
+   link: undefined,
    notes: undefined,
   },
   {

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ function App() {
    link: 'https://www.bakemonobakers.com.au/',
    notes:
     'Belinda recommended the garlic cream cheese bread and take home matcha latte kit',
+   id: 'placeholder1',
   },
   {
    restaurant: 'Marko',
@@ -24,6 +25,7 @@ function App() {
    price: '$',
    link: undefined,
    notes: undefined,
+   id: 'placeholder2',
   },
   {
    restaurant: 'Aru',
@@ -32,6 +34,7 @@ function App() {
    price: '$$$',
    link: 'https://www.broadsheet.com.au/melbourne/restaurants/aru-dining',
    notes: 'Bianca recommended the dry aged duck and claypot rice',
+   id: 'placeholder3',
   },
  ]
 

--- a/src/components/NewForm.js
+++ b/src/components/NewForm.js
@@ -18,6 +18,10 @@ function NewForm({ setData }) {
      name='restaurant'
      rules={[
       { required: true, message: 'Please input the name of the restaurant!' },
+      {
+       whitespace: true,
+       message: 'Please input the name of the restaurant!',
+      },
      ]}
     >
      <Input placeholder='e.g. Napier Quarter' />
@@ -28,6 +32,10 @@ function NewForm({ setData }) {
      rules={[
       {
        required: true,
+       message: 'Please input the suburb where the restaurant is located!',
+      },
+      {
+       whitespace: true,
        message: 'Please input the suburb where the restaurant is located!',
       },
      ]}

--- a/src/components/NewForm.js
+++ b/src/components/NewForm.js
@@ -3,14 +3,16 @@ import { Button, Card, Form, Input, Radio } from 'antd'
 const { TextArea } = Input
 
 function NewForm({ setData }) {
+ const [form] = Form.useForm()
  function onFinish(values) {
   console.log(values)
   setData((prevData) => [...prevData, values])
+  form.resetFields()
  }
  return (
   <Card>
    <h2>Add a new restaurant</h2>
-   <Form name='new' layout='vertical' onFinish={onFinish}>
+   <Form name='new' form={form} layout='vertical' onFinish={onFinish}>
     <Form.Item
      label='Restaurant'
      name='restaurant'

--- a/src/components/NewForm.js
+++ b/src/components/NewForm.js
@@ -35,6 +35,23 @@ function NewForm({ setData }) {
      <Input placeholder='e.g. Fitzroy' />
     </Form.Item>
     <Form.Item
+     label='Type'
+     name='type'
+     rules={[
+      {
+       required: true,
+       message: 'Please select the type of restaurant!',
+      },
+     ]}
+    >
+     <Radio.Group>
+      <Radio value={'Restaurant'}>Restaurant</Radio>
+      <Radio value={'Cafe'}>Cafe</Radio>
+      <Radio value={'Bar'}>Bar</Radio>
+      <Radio value={'Dessert'}>Dessert</Radio>
+     </Radio.Group>
+    </Form.Item>
+    <Form.Item
      label='Price'
      name='price'
      rules={[
@@ -49,6 +66,19 @@ function NewForm({ setData }) {
       <Radio value={'$$'}>$$</Radio>
       <Radio value={'$$$'}>$$$</Radio>
      </Radio.Group>
+    </Form.Item>
+    <Form.Item
+     label='Link'
+     name='link'
+     type='url'
+     rules={[
+      {
+       type: 'url',
+       message: 'Please input a valid URL!',
+      },
+     ]}
+    >
+     <Input placeholder='e.g. http://napierquarter.com.au/' />
     </Form.Item>
     <Form.Item label='Notes' name='notes'>
      <TextArea

--- a/src/components/NewForm.js
+++ b/src/components/NewForm.js
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid'
 import { Button, Card, Form, Input, Radio } from 'antd'
 
 const { TextArea } = Input
@@ -5,6 +6,7 @@ const { TextArea } = Input
 function NewForm({ setData }) {
  const [form] = Form.useForm()
  function onFinish(values) {
+  values.id = nanoid(10)
   console.log(values)
   setData((prevData) => [...prevData, values])
   form.resetFields()

--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -1,3 +1,4 @@
+import TypeEmoji from './TypeEmoji'
 import { Card, Space, Tag } from 'antd'
 import { EditOutlined, DeleteOutlined } from '@ant-design/icons'
 
@@ -12,18 +13,21 @@ function RestaurantList({ data }) {
        key={item.restaurant}
        actions={[<EditOutlined />, <DeleteOutlined />]}
       >
-       {item.link ? (
-        <a
-         href={item.link}
-         style={{ fontWeight: 600, color: 'black' }}
-         target='_blank'
-         rel='noopener noreferrer'
-        >
-         {item.restaurant} &#x2197;
-        </a>
-       ) : (
-        <p style={{ fontWeight: 600 }}> {item.restaurant}</p>
-       )}
+       <Space>
+        <TypeEmoji type={item.type} />
+        {item.link ? (
+         <a
+          href={item.link}
+          style={{ fontWeight: 600, color: 'black' }}
+          target='_blank'
+          rel='noopener noreferrer'
+         >
+          {item.restaurant} &#x2197;
+         </a>
+        ) : (
+         <p style={{ fontWeight: 600, display: 'inline' }}>{item.restaurant}</p>
+        )}
+       </Space>
        <p style={{ fontStyle: 'italic' }}>{item.notes}</p>
        <div>
         <Tag>{item.suburb}</Tag>

--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -12,7 +12,18 @@ function RestaurantList({ data }) {
        key={item.restaurant}
        actions={[<EditOutlined />, <DeleteOutlined />]}
       >
-       <p style={{ fontWeight: 600 }}> {item.restaurant}</p>
+       {item.link ? (
+        <a
+         href={item.link}
+         style={{ fontWeight: 600, color: 'black' }}
+         target='_blank'
+         rel='noopener noreferrer'
+        >
+         {item.restaurant} &#x2197;
+        </a>
+       ) : (
+        <p style={{ fontWeight: 600 }}> {item.restaurant}</p>
+       )}
        <p style={{ fontStyle: 'italic' }}>{item.notes}</p>
        <div>
         <Tag>{item.suburb}</Tag> <Tag color='green'>{item.price}</Tag>

--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -9,10 +9,7 @@ function RestaurantList({ data }) {
     <h2>Restaurant List</h2>
     {data.map((item) => {
      return (
-      <Card
-       key={item.restaurant}
-       actions={[<EditOutlined />, <DeleteOutlined />]}
-      >
+      <Card key={item.id} actions={[<EditOutlined />, <DeleteOutlined />]}>
        <Space>
         <TypeEmoji type={item.type} />
         {item.link ? (

--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -26,7 +26,9 @@ function RestaurantList({ data }) {
        )}
        <p style={{ fontStyle: 'italic' }}>{item.notes}</p>
        <div>
-        <Tag>{item.suburb}</Tag> <Tag color='green'>{item.price}</Tag>
+        <Tag>{item.suburb}</Tag>
+        <Tag color='blue'>{item.type}</Tag>
+        <Tag color='green'>{item.price}</Tag>
        </div>
       </Card>
      )

--- a/src/components/TypeEmoji.js
+++ b/src/components/TypeEmoji.js
@@ -1,0 +1,30 @@
+function TypeEmoji({ type }) {
+ switch (type) {
+  case 'Bar':
+   return (
+    <span role='img' aria-label='bar'>
+     🍸
+    </span>
+   )
+  case 'Cafe':
+   return (
+    <span role='img' aria-label='cafe'>
+     ☕
+    </span>
+   )
+  case 'Dessert':
+   return (
+    <span role='img' aria-label='dessert'>
+     🍩
+    </span>
+   )
+  default:
+   return (
+    <span role='img' aria-label='restaurant'>
+     🍽️
+    </span>
+   )
+ }
+}
+
+export default TypeEmoji

--- a/yarn.lock
+++ b/yarn.lock
@@ -7487,6 +7487,11 @@ nanoid@^3.1.20:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
   integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
 
+nanoid@^3.1.23:
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
+  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
**Description**
Add additional inputs to form to allow user to select type of restaurant and add a link

**Changes**
- Add `nanoid` to generate unique id key for each restaurant added
- Add function to reset fields on form when submitted
- Add `whitespace` rule to inputs so user cannot submit spaces for name, suburb and link
- Add `link` input with URL validation
- Render `<a>` on card if a link exists 
- Add `type` radio group to select type of restaurant
- Render a tag and emoji on card according to the type  
- Updated `placeholderData` object properties to match new data from form