### PR TITLE
feat: change delete confirmation dialog to modal

### DIFF
--- a/src/components/DeleteConfirm.js
+++ b/src/components/DeleteConfirm.js
@@ -1,4 +1,9 @@
-function DeleteConfirm() {
+function DeleteConfirm({
+ modalItem,
+ isDeleteModalVisible,
+ setIsDeleteModalVisible,
+ deleteItem,
+}) {
  return (
   <div>
    <p>DeleteConfirm</p>

--- a/src/components/DeleteConfirm.js
+++ b/src/components/DeleteConfirm.js
@@ -1,0 +1,9 @@
+function DeleteConfirm() {
+ return (
+  <div>
+   <p>DeleteConfirm</p>
+  </div>
+ )
+}
+
+export default DeleteConfirm

--- a/src/components/DeleteConfirm.js
+++ b/src/components/DeleteConfirm.js
@@ -1,13 +1,30 @@
+import { Modal } from 'antd'
+
 function DeleteConfirm({
  modalItem,
  isDeleteModalVisible,
  setIsDeleteModalVisible,
  deleteItem,
 }) {
+ const handleDeleteOk = () => {
+  deleteItem(modalItem.id)
+  setIsDeleteModalVisible(false)
+ }
+
+ const handleDeleteCancel = () => {
+  setIsDeleteModalVisible(false)
+ }
+
  return (
-  <div>
-   <p>DeleteConfirm</p>
-  </div>
+  <Modal
+   title={`Delete: ${modalItem.restaurant}`}
+   visible={isDeleteModalVisible}
+   onOk={handleDeleteOk}
+   onCancel={handleDeleteCancel}
+   okText='Confirm'
+  >
+   <p>Are you sure you want to delete {modalItem.restaurant} from your list?</p>
+  </Modal>
  )
 }
 

--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -63,7 +63,12 @@ function RestaurantList({ data, deleteItem, editItem }) {
      )
     })}
    </Space>
-   <DeleteConfirm />
+   <DeleteConfirm
+    modalItem={modalItem}
+    isDeleteModalVisible={isDeleteModalVisible}
+    setIsDeleteModalVisible={setIsDeleteModalVisible}
+    deleteItem={deleteItem}
+   />
    <EditForm
     modalItem={modalItem}
     isEditModalVisible={isEditModalVisible}

--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -1,4 +1,5 @@
 import TypeEmoji from './TypeEmoji'
+import DeleteConfirm from './DeleteConfirm'
 import EditForm from './EditForm'
 import { useState } from 'react'
 import { Card, Popconfirm, Space, Tag } from 'antd'
@@ -61,6 +62,7 @@ function RestaurantList({ data, deleteItem, editItem }) {
      )
     })}
    </Space>
+   <DeleteConfirm />
    <EditForm
     modalItem={modalItem}
     isEditModalVisible={isEditModalVisible}

--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -2,13 +2,19 @@ import TypeEmoji from './TypeEmoji'
 import DeleteConfirm from './DeleteConfirm'
 import EditForm from './EditForm'
 import { useState } from 'react'
-import { Card, Popconfirm, Space, Tag } from 'antd'
+import { Card, Space, Tag } from 'antd'
 import { EditOutlined, DeleteOutlined } from '@ant-design/icons'
 
 function RestaurantList({ data, deleteItem, editItem }) {
- const [isEditModalVisible, setIsEditModalVisible] = useState(false)
  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false)
+ const [isEditModalVisible, setIsEditModalVisible] = useState(false)
  const [modalItem, setModalItem] = useState(data[0])
+
+ const showDeleteModal = (id) => {
+  let dataItem = data.find((item) => item.id === id)
+  setModalItem(dataItem)
+  setIsDeleteModalVisible(true)
+ }
 
  const showEditModal = (id) => {
   let dataItem = data.find((item) => item.id === id)
@@ -26,16 +32,7 @@ function RestaurantList({ data, deleteItem, editItem }) {
        key={item.id}
        actions={[
         <EditOutlined onClick={() => showEditModal(item.id)} />,
-        <Popconfirm
-         title='Are you sure to delete this restaurant?'
-         onConfirm={() => {
-          deleteItem(item.id)
-         }}
-         okText='Yes'
-         cancelText='No'
-        >
-         <DeleteOutlined />
-        </Popconfirm>,
+        <DeleteOutlined onClick={() => showDeleteModal(item.id)} />,
        ]}
       >
        <Space>

--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -7,6 +7,7 @@ import { EditOutlined, DeleteOutlined } from '@ant-design/icons'
 
 function RestaurantList({ data, deleteItem, editItem }) {
  const [isEditModalVisible, setIsEditModalVisible] = useState(false)
+ const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false)
  const [modalItem, setModalItem] = useState(data[0])
 
  const showEditModal = (id) => {


### PR DESCRIPTION
**Description**
Change delete confirmation dialog from popconfirm to modal for ease of use on mobile. 

**Changes**
- Remove antd `<Popconfirm>` component 
- Add new `DeleteConfirm` component with modal 
- Pass down `deleteItem` function from `App.js` 